### PR TITLE
(#16) Simplify artifact version scheme

### DIFF
--- a/flink-shaded-asm-5/pom.xml
+++ b/flink-shaded-asm-5/pom.xml
@@ -29,9 +29,9 @@ under the License.
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-shaded-asm-5</artifactId>
+    <artifactId>flink-shaded-asm</artifactId>
     <name>flink-shaded-asm-5</name>
-    <version>1.0-${asm.version}</version>
+    <version>${asm.version}-1.0</version>
 
     <packaging>jar</packaging>
 

--- a/flink-shaded-guava-18/pom.xml
+++ b/flink-shaded-guava-18/pom.xml
@@ -29,9 +29,9 @@ under the License.
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-shaded-guava-18</artifactId>
+    <artifactId>flink-shaded-guava</artifactId>
     <name>flink-shaded-guava-18</name>
-    <version>1.0-${guava.version}</version>
+    <version>${guava.version}-1.0</version>
 
     <packaging>jar</packaging>
 

--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -29,9 +29,9 @@ under the License.
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-shaded-netty-4</artifactId>
+    <artifactId>flink-shaded-netty</artifactId>
     <name>flink-shaded-netty-4</name>
-    <version>1.0-${netty.version}</version>
+    <version>${netty.version}-1.0</version>
 
     <properties>
         <!-- Don't upgrade for now. Netty versions >= 4.0.28.Final


### PR DESCRIPTION
This PR modifies the version schemes, so that the final artifact names look like this:

`flink-shaded-asm-5.0.4-1.0`.

This name does not contain an underscore before the dependency version, in contrast to the issue description, since maven uses a dash to separate artifactId and version.