### PR TITLE
(#31) Add extended flink-shadaed-jackson-module-jsonSchema module

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded-jackson-parent</artifactId>
+        <version>2.7.9-3.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-jackson</artifactId>
+    <name>flink-shaded-jackson-2</name>
+
+</project>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded-jackson-parent</artifactId>
+        <version>2.7.9-3.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-jackson-module-jsonSchema</artifactId>
+    <name>flink-shaded-jackson-module-jsonSchema-2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jsonSchema</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -29,13 +29,19 @@ under the License.
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>flink-shaded-jackson</artifactId>
-    <name>flink-shaded-jackson-2</name>
+    <artifactId>flink-shaded-jackson-parent</artifactId>
+    <name>flink-shaded-jackson-parent</name>
+    <packaging>pom</packaging>
     <version>${jackson.version}-3.0</version>
 
     <properties>
         <jackson.version>2.7.9</jackson.version>
     </properties>
+
+    <modules>
+        <module>flink-shaded-jackson-2</module>
+        <module>flink-shaded-jackson-module-jsonSchema-2</module>
+    </modules>
 
     <dependencies>
         <dependency>
@@ -72,7 +78,7 @@ under the License.
                             <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <artifactSet>
                                 <includes>
-                                    <include>com.fasterxml.jackson.core:*</include>
+                                    <include>com.fasterxml.jackson.*:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -98,6 +104,5 @@ under the License.
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ under the License.
         <module>flink-shaded-asm-5</module>
         <module>flink-shaded-guava-18</module>
         <module>flink-shaded-netty-4</module>
-        <module>flink-shaded-jackson-2</module>
+        <module>flink-shaded-jackson-parent</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
This PR adds a second variant flink-shaded-jackson which also includes the jsonSchema module. Both variants now inherit from `flink-shaded-jackson-parent` which contains the shading configuration.