### PR TITLE
[FLINK-3952] Bump Netty to 4.1.24 and drop netty-router

### DIFF
--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <version>${netty.version}-4.0</version>
 
     <properties>
-        <netty.version>4.0.56.Final</netty.version>
+        <netty.version>4.1.24.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -42,12 +42,6 @@ under the License.
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>tv.cntt</groupId>
-            <artifactId>netty-router</artifactId>
-            <version>1.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This is a part of [FLINK-3952](https://issues.apache.org/jira/browse/FLINK-3952)