### PR TITLE
[FLINK-11219] Upgrade Jackson version to 2.9.6

### DIFF
--- a/flink-shaded-asm-5/pom.xml
+++ b/flink-shaded-asm-5/pom.xml
@@ -25,13 +25,13 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded</artifactId>
-        <version>6.0</version>
+        <version>1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-shaded-asm</artifactId>
     <name>flink-shaded-asm-5</name>
-    <version>${asm.version}-6.0</version>
+    <version>${asm.version}-1.0</version>
 
     <packaging>jar</packaging>
 

--- a/flink-shaded-asm-6/pom.xml
+++ b/flink-shaded-asm-6/pom.xml
@@ -25,12 +25,12 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded</artifactId>
-        <version>6.0</version>
+        <version>1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-shaded-asm-${asm.major.version}</artifactId>
-    <version>${asm.version}-6.0</version>
+    <version>${asm.version}-1.0</version>
 
     <packaging>jar</packaging>
 

--- a/flink-shaded-force-shading/pom.xml
+++ b/flink-shaded-force-shading/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <artifactId>flink-shaded</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>6.0</version>
+        <version>1.0</version>
     </parent>
 
     <artifactId>flink-shaded-force-shading</artifactId>

--- a/flink-shaded-guava-18/pom.xml
+++ b/flink-shaded-guava-18/pom.xml
@@ -25,13 +25,13 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded</artifactId>
-        <version>6.0</version>
+        <version>1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-shaded-guava</artifactId>
     <name>flink-shaded-guava-18</name>
-    <version>${guava.version}-6.0</version>
+    <version>${guava.version}-1.0</version>
 
     <packaging>jar</packaging>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.7.9-6.0</version>
+        <version>2.9.6-1.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.7.9-6.0</version>
+        <version>2.9.6-1.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -25,17 +25,17 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded</artifactId>
-        <version>6.0</version>
+        <version>1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-shaded-jackson-parent</artifactId>
     <name>flink-shaded-jackson-parent</name>
     <packaging>pom</packaging>
-    <version>2.7.9-6.0</version>
+    <version>2.9.6-1.0</version>
 
     <properties>
-        <jackson.version>2.7.9</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
     </properties>
 
     <modules>

--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -25,13 +25,13 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded</artifactId>
-        <version>6.0</version>
+        <version>1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-shaded-netty</artifactId>
     <name>flink-shaded-netty-4</name>
-    <version>${netty.version}-6.0</version>
+    <version>${netty.version}-1.0</version>
 
     <properties>
         <netty.version>4.1.24.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-shaded</artifactId>
-    <version>6.0</version>
+    <version>1.0</version>
 
     <name>flink-shaded</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
Upgrade Jackson version to 2.9.6
Because the Jackson version supported by calcite1.18.0 has been upgraded to Jackson 2.9.6.
Need to upgrade flink jackson in the shaded version
Because many flink dependency from the flink-shaded.

[https://github.com/apache/flink-shaded/issues/53](https://github.com/apache/flink-shaded/issues/53)