### PR TITLE
[FLINK-11580] Provide a shaded netty-tcnative

### DIFF
--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -91,7 +91,7 @@ under the License.
                 </executions>
                 <configuration>
                     <artifactItems>
-                        <!-- native wrapper libraries linked dynamically to OpenSSL - we will extract and these below-->
+                        <!-- native wrapper libraries linked dynamically to OpenSSL - we will extract, rename, and include these below-->
                         <artifactItem>
                             <groupId>io.netty</groupId>
                             <artifactId>netty-tcnative</artifactId>

--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded</artifactId>
+        <version>7.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-netty-tcnative-dynamic</artifactId>
+    <name>flink-shaded-netty-tcnative-dynamic</name>
+    <version>${netty.tcnative.version}-7.0</version>
+
+    <properties>
+        <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
+    </properties>
+
+    <dependencies>
+        <!-- Netty's native openSSL support -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative</artifactId>
+            <version>${netty.tcnative.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.netty:netty-tcnative</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <!-- native wrapper libraries linked dynamically to OpenSSL - we will extract and these below-->
+                        <artifactItem>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-tcnative</artifactId>
+                            <version>${netty.tcnative.version}</version>
+                            <classifier>linux-x86_64</classifier>
+                            <type>jar</type>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/native_libs</outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-tcnative</artifactId>
+                            <version>${netty.tcnative.version}</version>
+                            <classifier>linux-x86_64-fedora</classifier>
+                            <type>jar</type>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/native_libs</outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-tcnative</artifactId>
+                            <version>${netty.tcnative.version}</version>
+                            <classifier>osx-x86_64</classifier>
+                            <type>jar</type>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/native_libs</outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-tcnative</artifactId>
+                            <version>${netty.tcnative.version}</version>
+                            <classifier>windows-x86_64</classifier>
+                            <type>jar</type>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/native_libs</outputDirectory>
+                        </artifactItem>
+                    </artifactItems>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>rename-native-library</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <echo message="unpacking netty jar" />
+                                <unzip src="${project.build.directory}/${artifactId}-${version}.jar" dest="${project.build.directory}/unpacked/" />
+                                <echo message="extracting netty_tcnative dynamically linked wrapper libraries" />
+                                <!-- Fix the dynamically linked native libraries in netty-tcnative -->
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
+                                    <mapper type="glob" from="libnetty_tcnative.so" to="liborg_apache_flink_shaded_netty4_netty_tcnative_linux_x86_64.so"/>
+                                </move>
+                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-x86_64-fedora.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
+                                    <mapper type="glob" from="libnetty_tcnative.so" to="liborg_apache_flink_shaded_netty4_netty_tcnative_linux_x86_64_fedora.so"/>
+                                </move>
+                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-osx-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
+                                    <mapper type="glob" from="libnetty_tcnative.jnilib" to="liborg_apache_flink_shaded_netty4_netty_tcnative_osx_x86_64.jnilib"/>
+                                </move>
+                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-windows-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
+                                    <mapper type="glob" from="netty_tcnative.dll" to="org_apache_flink_shaded_netty4_netty_tcnative_windows_x86_64.dll"/>
+                                </move>
+                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
+                                <echo message="repackaging netty jar" />
+                                <jar destfile="${project.build.directory}/${artifactId}-${version}.jar" basedir="${project.build.directory}/unpacked" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-shaded-netty-openssl-static
+Copyright 2014-2019 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- io.netty:netty-tcnative:2.0.25.Final

--- a/flink-shaded-netty-tcnative-static/pom.xml
+++ b/flink-shaded-netty-tcnative-static/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded</artifactId>
+        <version>7.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-netty-tcnative-static</artifactId>
+    <name>flink-shaded-netty-tcnative-static</name>
+    <version>${netty.tcnative.version}-7.0</version>
+
+    <properties>
+        <netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
+    </properties>
+
+    <dependencies>
+        <!-- Netty's native openSSL support -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.tcnative.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.netty:netty-tcnative-boringssl-static</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>rename-native-library</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <echo message="unpacking netty jar" />
+                                <unzip src="${project.build.directory}/${artifactId}-${version}.jar" dest="${project.build.directory}/unpacked/" />
+                                <echo message="renaming netty_tcnative library" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/unpacked/META-INF/native"/>
+                                    <mapper type="regexp" from="(lib)?netty_tcnative_(linux_x86_64.so|osx_x86_64.jnilib|windows_x86_64.dll)" to="\1org_apache_flink_shaded_netty4_netty_tcnative_\2"/>
+                                </move>
+                                <echo message="repackaging netty jar" />
+                                <jar destfile="${project.build.directory}/${artifactId}-${version}.jar" basedir="${project.build.directory}/unpacked" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,14 @@
+flink-shaded-netty-openssl-static
+Copyright 2014-2019 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- io.netty:netty-tcnative-boringssl-static:2.0.25.Final
+
+This project bundles the following dependencies under the OpenSSL license.
+See bundled license files for details.
+
+- BoringSSL (statically linked native libraries)

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@ under the License.
         <module>flink-shaded-asm-6</module>
         <module>flink-shaded-guava-18</module>
         <module>flink-shaded-netty-4</module>
+        <module>flink-shaded-netty-tcnative-dynamic</module>
         <module>flink-shaded-jackson-parent</module>
         <module>flink-shaded-hadoop-2</module>
         <module>flink-shaded-hadoop-2-uber</module>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@ under the License.
     </modules>
 
     <profiles>
+        <!--
+            This module is excluded by default since it is not compliant with
+            the apache license. https://issues.apache.org/jira/browse/LEGAL-393
+        -->
         <profile>
             <id>include-netty-tcnative-static</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,18 @@ under the License.
 
     <profiles>
         <profile>
+            <id>include-netty-tcnative-static</id>
+            <activation>
+                <property>
+                    <name>include-netty-tcnative-static</name>
+                </property>
+            </activation>
+            <modules>
+                <module>flink-shaded-netty-tcnative-static</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>release</id>
             <build>
                 <plugins>


### PR DESCRIPTION
This PR provides two variants of a shaded netty-tcnative artifact:
- one with native libraries which are dynamically linked to openSSL: `flink-shaded-netty-tcnative-dynamic`, and
- one with native libraries which are statically linked to boringSSL: `flink-shaded-netty-tcnative-static`

Since the built artifact from `flink-shaded-netty-tcnative-static` contains binaries made from files under the openSSL license, we do not build these by default but enable the user to do this on his own via:
```
mvn clean install -Pinclude-netty-tcnative-static
```

More information on the differences can be found here:
- https://netty.io/wiki/requirements-for-4.x.html#wiki-h4-4
- https://netty.io/wiki/forked-tomcat-native.html
