### PR TITLE
 [FLINK-12515][Build System, BuildSystem / Shaded] Sync flink-shaded-hadoop with dependency management entries

### DIFF
--- a/flink-shaded-hadoop-2-uber/pom.xml
+++ b/flink-shaded-hadoop-2-uber/pom.xml
@@ -53,6 +53,41 @@ under the License.
 		</dependency>
 	</dependencies>
 
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- These exclusions should not be necessary (since they are already
+					included in flink-shaded-hadoop-2), but on some setups they are
+					being ignored.
+					The cause is unknown; this is just safeguard.-->
+				<groupId>org.apache.zookeeper</groupId>
+				<artifactId>zookeeper</artifactId>
+				<exclusions>
+					<exclusion>
+						<groupId>log4j</groupId>
+						<artifactId>log4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<!-- Netty is only needed for ZK servers, not clients -->
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>netty</artifactId>
+					</exclusion>
+					<!-- jline is optional for ZK console shell -->
+					<exclusion>
+						<groupId>jline</groupId>
+						<artifactId>jline</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+		</dependencies>
+
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 

--- a/flink-shaded-hadoop-2/pom.xml
+++ b/flink-shaded-hadoop-2/pom.xml
@@ -36,37 +36,137 @@ under the License.
 	<version>${hadoop.version}-7.0</version>
 
 	<properties>
+		<avro.version>1.8.2</avro.version>
+		<slf4j.version>1.7.15</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
 		<hadoop.version>2.4.1</hadoop.version>
+		<zookeeper.version>3.4.10</zookeeper.version>
 	</properties>
 
+	<dependencyManagement>
+		<!-- WARN:
+            DO NOT put 	guava,
+                        protobuf,
+                        asm,
+                        netty
+                    here. It will overwrite Hadoop's guava dependency (even though we handle it
+            separatly in this module).
+        -->
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.18</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro</artifactId>
+				<version>${avro.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.xerial.snappy</groupId>
+				<artifactId>snappy-java</artifactId>
+				<version>1.1.4</version>
+			</dependency>
+			<dependency>
+				<groupId>org.tukaani</groupId>
+				<artifactId>xz</artifactId>
+				<version>1.5</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>1.3.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-math3</artifactId>
+				<version>3.5</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.10</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.4</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-collections</groupId>
+				<artifactId>commons-collections</artifactId>
+				<version>3.2.2</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging</artifactId>
+				<version>1.1.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.4.6</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-configuration</groupId>
+				<artifactId>commons-configuration</artifactId>
+				<version>1.7</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>log4j</groupId>
+				<artifactId>log4j</artifactId>
+				<version>${log4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.zookeeper</groupId>
+				<artifactId>zookeeper</artifactId>
+				<version>${zookeeper.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>log4j</groupId>
+						<artifactId>log4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<!-- Netty is only needed for ZK servers, not clients -->
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>netty</artifactId>
+					</exclusion>
+					<!-- jline is optional for ZK console shell -->
+					<exclusion>
+						<groupId>jline</groupId>
+						<artifactId>jline</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+		</dependencies>
+
+	</dependencyManagement>
+
 	<dependencies>
-
-		<!--This is provided by Flink -->
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<scope>provided</scope>
-			<version>1.3.9</version>
-		</dependency>
-
-		<!--This is provided by Flink -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<scope>provided</scope>
-			<version>1.7.15</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<version>1.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<version>1.8.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
In this PR will add ` dependency management` entries for `flink-shaded-hadoop`. 

Process of consideration:
 1. DependencyList -> list all the dependency for `flink-shaded-hadoop` by `mvn dependency:tree`
 2.  TargetDependencyList -> find out the `artifactId` both in `DependencyList` and `flink-parent's dependencyManagement`. 
 3. add the `TargetDependencyList` into ` dependency management` of `flink-shaded-hadoop-2` in `flink-shaded`.
