### PR TITLE
[hotfix][hadoop] adds findfugs and slf4j-api as a provided dependency

### DIFF
--- a/flink-shaded-hadoop-2/pom.xml
+++ b/flink-shaded-hadoop-2/pom.xml
@@ -41,6 +41,7 @@ under the License.
 		<log4j.version>1.2.17</log4j.version>
 		<hadoop.version>2.4.1</hadoop.version>
 		<zookeeper.version>3.4.10</zookeeper.version>
+		<findbugs.version>1.3.9</findbugs.version>
 	</properties>
 
 	<dependencyManagement>
@@ -53,6 +54,11 @@ under the License.
             separatly in this module).
         -->
 		<dependencies>
+			<dependency>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>${findbugs.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
@@ -120,6 +126,11 @@ under the License.
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-log4j12</artifactId>
 				<version>${slf4j.version}</version>
 			</dependency>
@@ -158,6 +169,20 @@ under the License.
 	</dependencyManagement>
 
 	<dependencies>
+		<!-- drop dependencies that are already provided by Flink from the shaded / uber jars -->
+		<!--This is provided by Flink -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!--This is provided by Flink -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR adds `findfugs` and `slf4j-api` as a provided dependency.  the goal is to align the Flink master `flink-shaded-hadoop`did, as follows:
![image](https://user-images.githubusercontent.com/22488084/58301764-6d544700-7e1a-11e9-987a-3fcf55778d46.png)

What do you think? @zentol 

