### PR TITLE
[FLINK-12598] update maven-shade-plugin to version 3.1.1 for the shade-sources profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@ under the License.
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-shade-plugin</artifactId>
+                            <version>3.1.1</version>
                             <configuration combine.children="append">
                                 <createSourcesJar>true</createSourcesJar>
                                 <shadeSourcesContent>true</shadeSourcesContent>


### PR DESCRIPTION
In contrast to #63, this one only updates the maven-shade-plugin for the shade-sources build profile.

This fixes a potential NPE (seems to appear only with some maven versions) when
trying to shade sources with a dependency being unavailable.

Steps to reproduce the previous error (using maven 3.6.1):
```
> mvn clean package -Pshade-sources
...
[INFO] --- maven-shade-plugin:3.0.0:shade (shade-flink) @ flink-shaded-hadoop-2 ---
[INFO] Excluding org.apache.commons:commons-compress:jar:1.18 from the shaded jar.
[INFO] Excluding org.apache.avro:avro:jar:1.8.2 from the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-core-asl:jar:1.9.13 in the shaded jar.
[INFO] Including org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13 in the shaded jar.
[INFO] Excluding com.thoughtworks.paranamer:paranamer:jar:2.7 from the shaded jar.
[INFO] Excluding org.xerial.snappy:snappy-java:jar:1.1.4 from the shaded jar.
[INFO] Excluding org.tukaani:xz:jar:1.5 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-api:jar:1.7.7 from the shaded jar.
[INFO] Including org.apache.hadoop:hadoop-common:jar:2.4.1 in the shaded jar.
[INFO] Including org.apache.hadoop:hadoop-annotations:jar:2.4.1 in the shaded jar.
[INFO] Including com.google.guava:guava:jar:11.0.2 in the shaded jar.
[INFO] Excluding commons-cli:commons-cli:jar:1.3.1 from the shaded jar.
[INFO] Excluding org.apache.commons:commons-math3:jar:3.5 from the shaded jar.
[INFO] Excluding xmlenc:xmlenc:jar:0.52 from the shaded jar.
[INFO] Including commons-httpclient:commons-httpclient:jar:3.1 in the shaded jar.
[INFO] Excluding commons-codec:commons-codec:jar:1.10 from the shaded jar.
[INFO] Excluding commons-io:commons-io:jar:2.4 from the shaded jar.
[INFO] Excluding commons-net:commons-net:jar:3.1 from the shaded jar.
[INFO] Excluding commons-collections:commons-collections:jar:3.2.2 from the shaded jar.
[INFO] Excluding javax.servlet:servlet-api:jar:2.5 from the shaded jar.
[INFO] Excluding commons-el:commons-el:jar:1.0 from the shaded jar.
[INFO] Excluding commons-logging:commons-logging:jar:1.1.3 from the shaded jar.
[INFO] Excluding log4j:log4j:jar:1.2.17 from the shaded jar.
[INFO] Including net.java.dev.jets3t:jets3t:jar:0.9.0 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpclient:jar:4.5.3 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpcore:jar:4.4.6 in the shaded jar.
[INFO] Excluding com.jamesmurty.utils:java-xmlbuilder:jar:0.4 from the shaded jar.
[INFO] Excluding commons-lang:commons-lang:jar:2.6 from the shaded jar.
[INFO] Excluding commons-configuration:commons-configuration:jar:1.7 from the shaded jar.
[INFO] Excluding commons-digester:commons-digester:jar:1.8.1 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-log4j12:jar:1.7.15 from the shaded jar.
[INFO] Including com.google.protobuf:protobuf-java:jar:2.5.0 in the shaded jar.
[INFO] Including org.apache.hadoop:hadoop-auth:jar:2.4.1 in the shaded jar.
[INFO] Excluding com.jcraft:jsch:jar:0.1.42 from the shaded jar.
[INFO] Including com.google.code.findbugs:jsr305:jar:1.3.9 in the shaded jar.
[WARNING] Could not get sources for com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] flink-shaded 7.0 ................................... SUCCESS [  0.771 s]
[INFO] flink-shaded-force-shading 7.0 ..................... SUCCESS [  0.951 s]
[INFO] flink-shaded-asm-6 6.2.1-7.0 ....................... SUCCESS [  1.469 s]
[INFO] flink-shaded-guava-18 18.0-7.0 ..................... SKIPPED
[INFO] flink-shaded-netty-4 4.1.32.Final-7.0 .............. SKIPPED
[INFO] flink-shaded-netty-tcnative-dynamic 2.0.25.Final-7.0 SUCCESS [  2.195 s]
[INFO] flink-shaded-jackson-parent 2.9.8-7.0 .............. SUCCESS [  0.161 s]
[INFO] flink-shaded-jackson-2 2.9.8-7.0 ................... SKIPPED
[INFO] flink-shaded-jackson-module-jsonSchema-2 2.9.8-7.0 . SKIPPED
[INFO] flink-shaded-hadoop-2 2.4.1-7.0 .................... FAILURE [  2.597 s]
[INFO] flink-shaded-hadoop-2-uber 2.4.1-7.0 ............... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.499 s (Wall Clock)
[INFO] Finished at: 2019-05-23T09:22:04+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade (shade-flink) on project flink-shaded-hadoop-2: Execution shade-flink of goal org.apache.maven.plugins:maven-shade-plugin:3.0.0:shade failed.: NullPointerException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :flink-shaded-hadoop-2
```