### PR TITLE
[FLINK-13720][asm] Include asm-commons

### DIFF
--- a/flink-shaded-asm-7/pom.xml
+++ b/flink-shaded-asm-7/pom.xml
@@ -57,6 +57,12 @@ under the License.
             <artifactId>asm-analysis</artifactId>
             <version>${asm.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-shaded-asm-7/pom.xml
+++ b/flink-shaded-asm-7/pom.xml
@@ -90,7 +90,7 @@ under the License.
                             <relocations>
                                 <relocation>
                                     <pattern>org.objectweb</pattern>
-                                    <shadedPattern>${shading.prefix}.asm7.org.objectweb</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.asm${asm.major.version}.org.objectweb</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/flink-shaded-asm-7/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-asm-7/src/main/resources/META-INF/NOTICE
@@ -9,4 +9,5 @@ See bundled license files for details.
 
 - org.ow2.asm:asm:7.1
 - org.ow2.asm:asm-analysis:7.1
+- org.ow2.asm:asm-commons:7.1
 - org.ow2.asm:asm-tree:7.1

--- a/flink-shaded-asm-7/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-asm-7/src/main/resources/META-INF/NOTICE
@@ -1,4 +1,4 @@
-flink-shaded-asm6
+flink-shaded-asm7
 Copyright 2014-2018 The Apache Software Foundation
 
 This product includes software developed at


### PR DESCRIPTION
Includes asm-commons in flink-shaded-asm, as this is required for a rework of the serializer migration test base.

Additionally, contains a follow-up for FLINK-13467 which updates the major version in the NOTICE file, and a hotfix that simplifies future version bumps by relying on the `asm.major.version` property in the shading pattern.