### PR TITLE
[FLINK-13770][network] Bump Netty to 4.1.39.Final

### DIFF
--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <version>${netty.version}-8.0</version>
 
     <properties>
-        <netty.version>4.1.32.Final</netty.version>
+        <netty.version>4.1.39.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -91,6 +91,11 @@ under the License.
                                 <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
                                     <fileset dir="${project.build.directory}/unpacked/META-INF/native"/>
                                     <mapper type="glob" from="libnetty_transport_native_epoll_x86_64.so" to="liborg_apache_flink_shaded_netty4_netty_transport_native_epoll_x86_64.so"/>
+                                </move>
+                                <echo message="renaming native kqueue library" />
+                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
+                                    <fileset dir="${project.build.directory}/unpacked/META-INF/native"/>
+                                    <mapper type="glob" from="libnetty_transport_native_kqueue_x86_64.jnilib" to="liborg_apache_flink_shaded_netty4_netty_transport_native_kqueue_x86_64.jnilib"/>
                                 </move>
                                 <echo message="repackaging netty jar" />
                                 <jar destfile="${project.build.directory}/${artifactId}-${version}.jar" basedir="${project.build.directory}/unpacked" />

--- a/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-all:4.1.32.Final
+- io.netty:netty-all:4.1.39.Final


### PR DESCRIPTION
Below, you will find a list of bug fixes and performance improvements that may affect us. Nice
changes we could benefit from, also for the Java > 8 efforts. The most important ones fixing leaks etc are `#8921`, `#9167`, `#9274`, `#9394`, and the various `CompositeByteBuf` fixes. The rest are mostly performance improvements.

Also, it looks like Netty now supports Mac OS native `kqueue` transports in addition to `NIO` (all OS) and `epoll` (Linux). We could eventually enable this via `taskmanager.network.netty.transport` as well.

Since we are still early in the dev cycle for Flink 1.10, it would be nice to update now and verify that the new version works correctly.

```
Netty 4.1.33.Final
- Fix ClassCastException and native crash when using kqueue transport
(#8665)
- Provide a way to cache the internal nioBuffer of the PooledByteBuffer
to reduce GC (#8603)

Netty 4.1.34.Final
- Do not use GetPrimitiveArrayCritical(...) due multiple not-fixed bugs
related to GCLocker (#8921)
- Correctly monkey-patch id also in whe os / arch is used within library
name (#8913)
- Further reduce ensureAccessible() overhead (#8895)
- Support using an Executor to offload blocking / long-running tasks
when processing TLS / SSL via the SslHandler (#8847)
- Minimize memory footprint for AbstractChannelHandlerContext for
handlers that execute in the EventExecutor (#8786)
- Fix three bugs in CompositeByteBuf (#8773)

Netty 4.1.35.Final
- Fix possible ByteBuf leak when CompositeByteBuf is resized (#8946)
- Correctly produce ssl alert when certificate validation fails on the
client-side when using native SSL implementation (#8949)

Netty 4.1.37.Final
- Don't filter out TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (#9274)
- Try to mark child channel writable again once the parent channel
becomes writable (#9254)
- Properly debounce wakeups (#9191)
- Don't read from timerfd and eventfd on each EventLoop tick (#9192)
- Correctly detect that KeyManagerFactory is not supported when using
OpenSSL 1.1.0+ (#9170)
- Fix possible unsafe sharing of internal NIO buffer in CompositeByteBuf
(#9169)
- KQueueEventLoop won't unregister active channels reusing a file
descriptor (#9149)
- Prefer direct io buffers if direct buffers pooled (#9167)

Netty 4.1.38.Final
- Prevent ByteToMessageDecoder from overreading when !isAutoRead (#9252)
- Correctly take length of ByteBufInputStream into account for
readLine() / readByte() (#9310)
- availableSharedCapacity will be slowly exhausted (#9394)
```