### PR TITLE
[FLINK-14072] Add a third-party maven repository for flink-shaded.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,50 @@ under the License.
                 <module>flink-shaded-netty-tcnative-static</module>
             </modules>
         </profile>
-
+        <profile>
+            <id>vendor-repos</id>
+            <activation>
+                <property>
+                    <name>vendor-repos</name>
+                </property>
+            </activation>
+            <!-- Add vendor maven repositories -->
+            <repositories>
+                <!-- Cloudera -->
+                <repository>
+                    <id>cloudera-releases</id>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <!-- Hortonworks -->
+                <repository>
+                    <id>HDPReleases</id>
+                    <name>HDP Releases</name>
+                    <url>https://repo.hortonworks.com/content/repositories/releases/</url>
+                    <snapshots><enabled>false</enabled></snapshots>
+                    <releases><enabled>true</enabled></releases>
+                </repository>
+                <repository>
+                    <id>HortonworksJettyHadoop</id>
+                    <name>HDP Jetty</name>
+                    <url>https://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
+                    <snapshots><enabled>false</enabled></snapshots>
+                    <releases><enabled>true</enabled></releases>
+                </repository>
+                <!-- MapR -->
+                <repository>
+                    <id>mapr-releases</id>
+                    <url>https://repository.mapr.com/maven/</url>
+                    <snapshots><enabled>false</enabled></snapshots>
+                    <releases><enabled>true</enabled></releases>
+                </repository>
+            </repositories>
+        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
Add a third-party maven repository to avoid the package being found when custom compiling. Such as CDH,HDP,MapR.
In this way, we can customize the source code of Flink-shaded. For example, execute the following command:
`mvn clean install -Dmaven.test.skip=true -Dhadoop.version=3.0.0-cdh6.3.0 -Pvendor-repos`

Hi, @zentol @NicoK @sunjincheng121 Please take a look, Thank you very much.