### PR TITLE
[FLINK-14104][jackson] Bump up to version 2.9.9[.3]

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.9.8-9.0</version>
+        <version>2.10.1-9.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.9.8
-- com.fasterxml.jackson.core:jackson-core:2.9.8
-- com.fasterxml.jackson.core:jackson-databind:2.9.8
-- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.8
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8
-- org.yaml:snakeyaml:1.18
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.10.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- org.yaml:snakeyaml:1.24

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.9.8-9.0</version>
+        <version>2.10.1-9.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.9.8
-- com.fasterxml.jackson.core:jackson-core:2.9.8
-- com.fasterxml.jackson.core:jackson-databind:2.9.8
-- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.9.8
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.10.1
 - javax.validation:validation-api:1.1.0.Final

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -32,10 +32,10 @@ under the License.
     <artifactId>flink-shaded-jackson-parent</artifactId>
     <name>flink-shaded-jackson-parent</name>
     <packaging>pom</packaging>
-    <version>2.9.8-9.0</version>
+    <version>2.10.1-9.0</version>
 
     <properties>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.10.1</jackson.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,9 @@ under the License.
             </build>
         </profile>
         <profile>
-            <id>java9</id>
+            <id>java11</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>11</jdk>
             </activation>
 
             <build>
@@ -139,7 +139,7 @@ under the License.
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-shade-plugin</artifactId>
-                            <version>3.1.1</version>
+                            <version>3.2.1</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>


### PR DESCRIPTION
This fixes the following vulnerabilities:
- CVE-2019-12384
- CVE-2019-12814
- CVE-2019-14379
- CVE-2019-14439

See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink-shaded/72)
<!-- Reviewable:end -->
