### PR TITLE
[FLINK-14413][build] Specify encoding for ApacheNoticeResourceTransformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@ under the License.
                             <!-- The ApacheNoticeResourceTransformer collects and aggregates NOTICE files -->
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
                                 <projectName>Apache Flink-shaded</projectName>
+                                <encoding>UTF-8</encoding>
                             </transformer>
                         </transformers>
                     </configuration>


### PR DESCRIPTION
Pins the encoding for the `ApacheNoticeResourceTransformer`. Without this the transformer reads/writes all files using a platform-dependent encoding, which makes some parts of the build non-deterministic.