### PR TITLE
[FLINK-15742][build] Add curator/zookeeper module

### DIFF
--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-34/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-34/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded-zookeeper-parent</artifactId>
+        <version>10.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-zookeeper-3</artifactId>
+    <name>flink-shaded-zookeeper-3.4</name>
+    <version>${zookeeper.version}-10.0</version>
+
+    <properties>
+        <zookeeper.version>3.4.10</zookeeper.version>
+        <curator.version>4.2.0</curator.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- only required for ZK servers, not clients -->
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- only required for ZK console shell -->
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>failureaccess</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-34/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-34/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,13 @@
+flink-shaded-zookeeper-3
+Copyright 2014-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:27.0.1-jre
+- org.apache.curator:curator-client:4.2.0
+- org.apache.curator:curator-framework:4.2.0
+- org.apache.curator:curator-recipes:4.2.0
+- org.apache.zookeeper:zookeeper:3.4.10

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded-zookeeper-parent</artifactId>
+        <version>10.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-zookeeper-3</artifactId>
+    <name>flink-shaded-zookeeper-3.5</name>
+    <version>${zookeeper.version}-10.0</version>
+
+    <properties>
+        <zookeeper.version>3.5.6</zookeeper.version>
+        <curator.version>4.2.0</curator.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- only required for ZK servers, not clients -->
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>failureaccess</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,14 @@
+flink-shaded-zookeeper-3
+Copyright 2014-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:27.0.1-jre
+- org.apache.curator:curator-client:4.2.0
+- org.apache.curator:curator-framework:4.2.0
+- org.apache.curator:curator-recipes:4.2.0
+- org.apache.zookeeper:zookeeper:3.5.5
+- org.apache.zookeeper:zookeeper-jute:3.5.5

--- a/flink-shaded-zookeeper-parent/pom.xml
+++ b/flink-shaded-zookeeper-parent/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded</artifactId>
+        <version>10.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-zookeeper-parent</artifactId>
+    <name>flink-shaded-zookeeper-parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>flink-shaded-zookeeper-34</module>
+        <module>flink-shaded-zookeeper-35</module>
+    </modules>
+
+    <properties>
+        <shading.zookeeper.prefix>org.apache.flink.shaded.zookeeper3</shading.zookeeper.prefix>
+        <shading.curator.prefix>org.apache.flink.shaded.curator4</shading.curator.prefix>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <artifactSet>
+                                <includes>
+                                    <include>*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>${shading.zookeeper.prefix}.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.jute</pattern>
+                                    <shadedPattern>${shading.zookeeper.prefix}.org.apache.jute</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>${shading.curator.prefix}.org.apache.curator</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>${shading.curator.prefix}.com.google</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@ under the License.
         <module>flink-shaded-netty-tcnative-dynamic</module>
         <module>flink-shaded-jackson-parent</module>
         <module>flink-shaded-hadoop-2-parent</module>
+        <module>flink-shaded-zookeeper-parent</module>
     </modules>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,14 @@ under the License.
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
+                        <filters combine.children="append">
+                            <filter>
+                                <artifact>*</artifact>
+                                <excludes>
+                                    <exclude>META-INF/maven/**</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
                         <transformers>
                             <!-- The service transformer is needed to merge META-INF/services files -->
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>


### PR DESCRIPTION
Adds 2 new modules that bundle zookeeper (3.4.10/3.5.5) and curator-recipes (4.2.0). Both modules are self-contained and use the same shading pattern (required so that Flink can easily switch between them).

Both modules exclude most dependencies (based on the existing shading logic in the Flink master) and as a result only bundle apache-llicensed dependencies (yay!).

I have verified that these versions work with a modified Flink 1.11 against zookeeper 3.4.14 (with the 3.4 module) and 3.5.6 (with both modules).

A preview of the intended Flink setup can be found here: https://github.com/zentol/flink/tree/zk_cur