### PR TITLE
[FLINK-16527][build] Resolve properties in version field

### DIFF
--- a/flink-shaded-asm-7/pom.xml
+++ b/flink-shaded-asm-7/pom.xml
@@ -97,6 +97,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/flink-shaded-guava-18/pom.xml
+++ b/flink-shaded-guava-18/pom.xml
@@ -77,6 +77,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/flink-shaded-hadoop-2-parent/flink-shaded-hadoop-2-uber/pom.xml
+++ b/flink-shaded-hadoop-2-parent/flink-shaded-hadoop-2-uber/pom.xml
@@ -189,6 +189,12 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<!-- Used to resolve variables in the 'version' tag -->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-shaded-hadoop-2-parent/flink-shaded-hadoop-2/pom.xml
+++ b/flink-shaded-hadoop-2-parent/flink-shaded-hadoop-2/pom.xml
@@ -975,6 +975,11 @@ under the License.
 				</executions>
 			</plugin>
 
+			<plugin>
+				<!-- Used to resolve variables in the 'version' tag -->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -82,6 +82,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -77,6 +77,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -107,6 +107,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -179,6 +179,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/flink-shaded-netty-tcnative-static/pom.xml
+++ b/flink-shaded-netty-tcnative-static/pom.xml
@@ -103,6 +103,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/flink-shaded-zookeeper-parent/pom.xml
+++ b/flink-shaded-zookeeper-parent/pom.xml
@@ -85,6 +85,12 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@ under the License.
                     <executions>
                         <execution>
                             <id>flatten</id>
-                            <phase>none</phase>
+                            <phase>package</phase>
                             <goals>
                                 <goal>flatten</goal>
                             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@ under the License.
                                 <!-- The least invasive mode that effectively only resolves variables -->
                                 <flattenMode>resolveCiFriendliesOnly</flattenMode>
                                 <!-- By default the resulting pom is written into the modules base directory to work around MNG-6405.
-                                    We aren't affected, os we use the proper location. -->
+                                    We aren't affected, so we use the proper location. -->
                                 <outputDirectory>${project.build.directory}</outputDirectory>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,36 @@ under the License.
                         </transformers>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <!-- Used to resolve variables in the 'version' tag -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                            <configuration>
+                                <!-- The least invasive mode that effectively only resolves variables -->
+                                <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                                <!-- By default the resulting pom is written into the modules base directory to work around MNG-6405.
+                                    We aren't affected, os we use the proper location. -->
+                                <outputDirectory>${project.build.directory}</outputDirectory>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>flatten.clean</id>
+                            <phase>clean</phase>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
During the build process we rely on the `shade-plugin` to replace references to properties (e.g., `${scala.binary.version}`) by their actual value.
This is important because the property _field_ cannot be changed during the build. If you set a property on the command-line the _field_ is not updated, only the in-memory analogue is.
Hence any references to the property after the build process are problematic because you can have a value mismatch between the value set in the field vs the one set at build-time.

Turns out the shade-plugin does not resolve properties in the `<version>` field, resulting in an inconsistency which some build systems outright reject.

We now additionally use the `flatten-plugin` to resolve _all_ properties.
The primary purpose of this plugin is to create fully self-contained poms without any references to parents and what-not; since we only care about properties we run it in it's `resolveCiFriendliesOnly` mode, which is the least invasive mode of operation.
(For us) it only resolves properties and copies the `license` field into the root pom (which is fine, but unfortunate).