### PR TITLE
[FLINK-23325] Bump netty to 4.1.65

### DIFF
--- a/flink-shaded-netty-4/pom.xml
+++ b/flink-shaded-netty-4/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <version>${netty.version}-14.0</version>
 
     <properties>
-        <netty.version>4.1.49.Final</netty.version>
+        <netty.version>4.1.65.Final</netty.version>
     </properties>
 
     <dependencies>

--- a/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-all:4.1.49.Final
+- io.netty:netty-all:4.1.63.Final

--- a/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-all:4.1.63.Final
+- io.netty:netty-all:4.1.65.Final

--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -154,7 +154,7 @@ under the License.
                                     <mapper type="glob" from="lib*" to="liborg_apache_flink_shaded_netty4_*"/>
                                 </move>
                                 <delete dir="${project.build.directory}/native_libs/unpacked/" />
-                                <!-- the fedora linux .so file has the same name as the one for plain linux, so we need to separately extract, relocate and copy it -->
+                                <!-- the fedora linux .so file has the same name as the one for plain linux, so we need to separately extract, relocate and move it -->
                                 <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-x86_64-fedora.jar" dest="${project.build.directory}/native_libs/unpacked/" />
                                 <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
                                     <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>

--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -34,7 +34,8 @@ under the License.
     <version>${netty.tcnative.version}-14.0</version>
 
     <properties>
-        <netty.tcnative.version>2.0.30.Final</netty.tcnative.version>
+        <!-- This is based on the "tcnative.version" property in the netty root pom-->
+        <netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
     </properties>
 
     <dependencies>
@@ -123,7 +124,7 @@ under the License.
                             <groupId>io.netty</groupId>
                             <artifactId>netty-tcnative</artifactId>
                             <version>${netty.tcnative.version}</version>
-                            <classifier>windows-x86_64</classifier>
+                            <classifier>linux-aarch_64-fedora</classifier>
                             <type>jar</type>
                             <overWrite>false</overWrite>
                             <outputDirectory>${project.build.directory}/native_libs</outputDirectory>
@@ -146,27 +147,18 @@ under the License.
                                 <echo message="extracting netty_tcnative dynamically linked wrapper libraries" />
                                 <!-- Fix the dynamically linked native libraries in netty-tcnative -->
                                 <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-osx-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
+                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-aarch_64-fedora.jar" dest="${project.build.directory}/native_libs/unpacked/" />
                                 <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
                                     <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
-                                    <mapper type="glob" from="libnetty_tcnative.so" to="liborg_apache_flink_shaded_netty4_netty_tcnative_linux_x86_64.so"/>
+                                    <mapper type="glob" from="lib*" to="liborg_apache_flink_shaded_netty4_*"/>
                                 </move>
                                 <delete dir="${project.build.directory}/native_libs/unpacked/" />
+                                <!-- the fedora linux .so file has the same name as the one for plain linux, so we need to separately extract, relocate and copy it -->
                                 <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-linux-x86_64-fedora.jar" dest="${project.build.directory}/native_libs/unpacked/" />
                                 <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
                                     <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
-                                    <mapper type="glob" from="libnetty_tcnative.so" to="liborg_apache_flink_shaded_netty4_netty_tcnative_linux_x86_64_fedora.so"/>
-                                </move>
-                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
-                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-osx-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
-                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
-                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
-                                    <mapper type="glob" from="libnetty_tcnative.jnilib" to="liborg_apache_flink_shaded_netty4_netty_tcnative_osx_x86_64.jnilib"/>
-                                </move>
-                                <delete dir="${project.build.directory}/native_libs/unpacked/" />
-                                <unzip src="${project.build.directory}/native_libs/netty-tcnative-${netty.tcnative.version}-windows-x86_64.jar" dest="${project.build.directory}/native_libs/unpacked/" />
-                                <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
-                                    <fileset dir="${project.build.directory}/native_libs/unpacked/META-INF/native"/>
-                                    <mapper type="glob" from="netty_tcnative.dll" to="org_apache_flink_shaded_netty4_netty_tcnative_windows_x86_64.dll"/>
+                                    <mapper type="glob" from="lib*.so" to="liborg_apache_flink_shaded_netty4_*_fedora.so"/>
                                 </move>
                                 <delete dir="${project.build.directory}/native_libs/unpacked/" />
                                 <echo message="repackaging netty jar" />

--- a/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-tcnative:2.0.30.Final
+- io.netty:netty-tcnative:2.0.39.Final

--- a/flink-shaded-netty-tcnative-static/pom.xml
+++ b/flink-shaded-netty-tcnative-static/pom.xml
@@ -34,7 +34,8 @@ under the License.
     <version>${netty.tcnative.version}-14.0</version>
 
     <properties>
-        <netty.tcnative.version>2.0.30.Final</netty.tcnative.version>
+        <!-- This is based on the "tcnative.version" property in the netty root pom-->
+        <netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
     </properties>
 
     <dependencies>
@@ -91,7 +92,7 @@ under the License.
                                 <echo message="renaming netty_tcnative library" />
                                 <move todir="${project.build.directory}/unpacked/META-INF/native" includeemptydirs="false">
                                     <fileset dir="${project.build.directory}/unpacked/META-INF/native"/>
-                                    <mapper type="regexp" from="(lib)?netty_tcnative_(linux_x86_64.so|osx_x86_64.jnilib|windows_x86_64.dll)" to="\1org_apache_flink_shaded_netty4_netty_tcnative_\2"/>
+                                    <mapper type="regexp" from="(lib)?netty_tcnative_(linux_x86_64.so|linux_aarch_64.so|osx_x86_64.jnilib|windows_x86_64.dll)" to="\1org_apache_flink_shaded_netty4_netty_tcnative_\2"/>
                                 </move>
                                 <echo message="repackaging netty jar" />
                                 <jar destfile="${project.build.directory}/${artifactId}-${version}.jar" basedir="${project.build.directory}/unpacked" />

--- a/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-tcnative-boringssl-static:2.0.30.Final
+- io.netty:netty-tcnative-boringssl-static:2.0.39.Final
 
 This project bundles the following dependencies under the OpenSSL license.
 See bundled license files for details.


### PR DESCRIPTION
Our shading setup for native bindings, which need to be bumped to 2.0.39, needed most of the changes.
- The netty files have been renamed, so I had to adjust our file matching & renaming.
- the dynamic windows binding appears to no longer exist 🤷 
- there's now a dynamic binding for ARM
- there's now a dynamic binding specific to Fedora Linux, which needs some special handling because the file name clash with the vanilla Linux one (voidig some of the benefits of renaming things in the first place...)