### PR TITLE
[FLINK-23326] Bump guava to 30.1.1-jre

### DIFF
--- a/flink-shaded-guava-18/pom.xml
+++ b/flink-shaded-guava-18/pom.xml
@@ -36,7 +36,7 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <guava.version>18.0</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -44,6 +44,13 @@ under the License.
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- this dependency is actually empty and appears to be some weird legacy artifact -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -70,7 +77,7 @@ under the License.
                             <relocations>
                                 <relocation>
                                     <pattern>com.google</pattern>
-                                    <shadedPattern>${shading.prefix}.guava18.com.google</shadedPattern>
+                                    <shadedPattern>${shading.prefix}.guava30.com.google</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/flink-shaded-guava-18/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-guava-18/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.google.guava:guava:18.0
+- com.google.guava:guava:30.1.1-jre
+- com.google.guava:failureaccess:1.0.1


### PR DESCRIPTION
A big dependency bump that was long overdue.
The `failureaccess` dependency is something that was previously part of guava, and now is a separate artifact.
They also tried something similar with `listenablefuture`, which apparently did not work out so well, and now they are stuck with an empty artifact in their dependency tree 🤦 . 