### PR TITLE
[FLINK-23291] Bump jackson to 2.12.4 

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -62,7 +62,7 @@ under the License.
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.27</version>
+                <version>1.29</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.12.1-14.0</version>
+        <version>2.12.4-14.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.12.4
+- com.fasterxml.jackson.core:jackson-core:2.12.4
+- com.fasterxml.jackson.core:jackson-databind:2.12.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.12.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4
 - org.yaml:snakeyaml:1.27

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
@@ -11,4 +11,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.12.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.12.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4
-- org.yaml:snakeyaml:1.27
+- org.yaml:snakeyaml:1.29

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.12.1-14.0</version>
+        <version>2.12.4-14.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.12.4
+- com.fasterxml.jackson.core:jackson-core:2.12.4
+- com.fasterxml.jackson.core:jackson-databind:2.12.4
+- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.12.4
 - javax.validation:validation-api:1.1.0.Final

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -32,10 +32,10 @@ under the License.
     <artifactId>flink-shaded-jackson-parent</artifactId>
     <name>flink-shaded-jackson-parent</name>
     <packaging>pom</packaging>
-    <version>2.12.1-14.0</version>
+    <version>2.12.4-14.0</version>
 
     <properties>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Bumps jackson and the contained snakeyaml. The updates are only fixing bugs; nothing security related afaict.