### PR TITLE
[FLINK-23299] Bump Zookeeper to 3.5.9

### DIFF
--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <version>${zookeeper.version}-14.0</version>
 
     <properties>
-        <zookeeper.version>3.5.6</zookeeper.version>
+        <zookeeper.version>3.5.9</zookeeper.version>
         <curator.version>4.2.0</curator.version>
     </properties>
 

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-35/src/main/resources/META-INF/NOTICE
@@ -10,5 +10,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.curator:curator-client:4.2.0
 - org.apache.curator:curator-framework:4.2.0
 - org.apache.curator:curator-recipes:4.2.0
-- org.apache.zookeeper:zookeeper:3.5.6
-- org.apache.zookeeper:zookeeper-jute:3.5.6
+- org.apache.zookeeper:zookeeper:3.5.9
+- org.apache.zookeeper:zookeeper-jute:3.5.9


### PR DESCRIPTION
Upgrades out ZK 3.5 dependency to the latest bugfix release. Contains both bug and security fixes.

ZK 3.5 is still a supported version, hence we're sticking with it for the time being instead of jumping to 3.6, which would also require a curator upgrade.