### PR TITLE
[FLINK-25016] Upgrade Netty to 4.1.70

### DIFF
--- a/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-4/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,36 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-all:4.1.65.Final
+- io.netty:netty-all:4.1.70.Final
+- io.netty:netty-buffer:4.1.70.Final
+- io.netty:netty-codec:4.1.70.Final
+- io.netty:netty-codec-dns:4.1.70.Final
+- io.netty:netty-codec-haproxy:4.1.70.Final
+- io.netty:netty-codec-http:4.1.70.Final
+- io.netty:netty-codec-http2:4.1.70.Final
+- io.netty:netty-codec-memcache:4.1.70.Final
+- io.netty:netty-codec-mqtt:4.1.70.Final
+- io.netty:netty-codec-redis:4.1.70.Final
+- io.netty:netty-codec-smtp:4.1.70.Final
+- io.netty:netty-codec-socks:4.1.70.Final
+- io.netty:netty-codec-stomp:4.1.70.Final
+- io.netty:netty-codec-xml:4.1.70.Final
+- io.netty:netty-common:4.1.70.Final
+- io.netty:netty-handler:4.1.70.Final
+- io.netty:netty-handler-proxy:4.1.70.Final
+- io.netty:netty-resolver:4.1.70.Final
+- io.netty:netty-resolver-dns:4.1.70.Final
+- io.netty:netty-resolver-dns-classes-macos:4.1.70.Final
+- io.netty:netty-resolver-dns-native-macos:osx-x86_64:4.1.70.Final
+- io.netty:netty-resolver-dns-native-macos:osx-aarch_64:4.1.70.Final
+- io.netty:netty-transport:4.1.70.Final
+- io.netty:netty-transport-classes-epoll:4.1.70.Final
+- io.netty:netty-transport-classes-kqueue:4.1.70.Final
+- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.70.Final
+- io.netty:netty-transport-native-epoll:linux-aarch_64:4.1.70.Final
+- io.netty:netty-transport-native-kqueue:osx-x86_64:4.1.70.Final
+- io.netty:netty-transport-native-kqueue:osx-aarch_64:4.1.70.Final
+- io.netty:netty-transport-native-unix-common:4.1.70.Final
+- io.netty:netty-transport-rxtx:4.1.70.Final
+- io.netty:netty-transport-sctp:4.1.70.Final
+- io.netty:netty-transport-udt:4.1.70.Final

--- a/flink-shaded-netty-tcnative-dynamic/pom.xml
+++ b/flink-shaded-netty-tcnative-dynamic/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
     <properties>
         <!-- This is based on the "tcnative.version" property in the netty root pom-->
-        <netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.44.Final</netty.tcnative.version>
     </properties>
 
     <dependencies>

--- a/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-dynamic/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-tcnative:2.0.39.Final
+- io.netty:netty-tcnative:2.0.44.Final

--- a/flink-shaded-netty-tcnative-static/pom.xml
+++ b/flink-shaded-netty-tcnative-static/pom.xml
@@ -35,7 +35,7 @@ under the License.
 
     <properties>
         <!-- This is based on the "tcnative.version" property in the netty root pom-->
-        <netty.tcnative.version>2.0.39.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.44.Final</netty.tcnative.version>
     </properties>
 
     <dependencies>

--- a/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.netty:netty-tcnative-boringssl-static:2.0.39.Final
+- io.netty:netty-tcnative-boringssl-static:2.0.44.Final
 
 This project bundles the following dependencies under the OpenSSL license.
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
 
     <properties>
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
-        <netty.version>4.1.65.Final</netty.version>
+        <netty.version>4.1.70.Final</netty.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
CI run with Flink using the updated version: https://dev.azure.com/chesnay/flink/_build/results?buildId=1796