### PR TITLE
[FLINK-25145] Add Zookeeper 3.6

### DIFF
--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/pom.xml
@@ -56,7 +56,12 @@ under the License.
                 <exclusion>
                     <!-- Flink distribution provides logging classes -->
                     <groupId>org.slf4j</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -67,6 +72,18 @@ under the License.
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>3.2.5</version>
+            <exclusions>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-shaded-zookeeper-parent</artifactId>
+        <version>15.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-shaded-zookeeper-3</artifactId>
+    <name>flink-shaded-zookeeper-3.6</name>
+    <version>${zookeeper.version}-15.0</version>
+
+    <properties>
+        <zookeeper.version>3.6.3</zookeeper.version>
+        <curator.version>5.2.0</curator.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Zookeeper dependency, that is inexplicably set to provided.
+                 Unfortunately not optional, because the ServerMetrics class, again inexplicably,
+                 has a hard dependency on it for testing purposes.-->
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>failureaccess</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- supposedly not required -->
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not relevant at runtime -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Flink distribution provides logging classes -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-36/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,23 @@
+flink-shaded-zookeeper-3
+Copyright 2014-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.google.guava:guava:27.0.1-jre
+- io.dropwizard.metrics:metrics-core:3.2.5
+- io.netty:netty-buffer:4.1.70.Final
+- io.netty:netty-codec:4.1.70.Final
+- io.netty:netty-common:4.1.70.Final
+- io.netty:netty-handler:4.1.70.Final
+- io.netty:netty-resolver:4.1.70.Final
+- io.netty:netty-transport:4.1.70.Final
+- io.netty:netty-transport-native-epoll:4.1.70.Final
+- io.netty:netty-transport-native-unix-common:4.1.70.Final
+- org.apache.curator:curator-client:5.2.0
+- org.apache.curator:curator-framework:5.2.0
+- org.apache.curator:curator-recipes:5.2.0
+- org.apache.zookeeper:zookeeper:3.6.3
+- org.apache.zookeeper:zookeeper-jute:3.6.3

--- a/flink-shaded-zookeeper-parent/pom.xml
+++ b/flink-shaded-zookeeper-parent/pom.xml
@@ -35,6 +35,7 @@ under the License.
 
     <modules>
         <module>flink-shaded-zookeeper-35</module>
+        <module>flink-shaded-zookeeper-36</module>
     </modules>
 
     <properties>
@@ -74,6 +75,10 @@ under the License.
                                 <relocation>
                                     <pattern>org.apache.jute</pattern>
                                     <shadedPattern>${shading.zookeeper.prefix}.org.apache.jute</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.codahale.metrics</pattern>
+                                    <shadedPattern>${shading.zookeeper.prefix}.com.codahale.metrics</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.curator</pattern>


### PR DESCRIPTION
Pretty similar to the current 3.5 module. Main difference is the ZK version (duh), and that we also bundle `io.dropwizard.metrics:metrics-core`.

A Flink build with the required changes can be seen here: https://dev.azure.com/chesnay/flink/_build/results?buildId=1850&view=results