### PR TITLE
[FLINK-27293] Update jackson-bom to address CVE-2020-36518

### DIFF
--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -32,10 +32,10 @@ under the License.
     <artifactId>flink-shaded-jackson-parent</artifactId>
     <name>flink-shaded-jackson-parent</name>
     <packaging>pom</packaging>
-    <version>2.12.4-16.0</version>
+    <version>2.12.6.20220326-16.0</version>
 
     <properties>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.12.6.20220326</jackson.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Addressing https://github.com/advisories/GHSA-57j2-w4cx-62h2

References:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12#micro-patches
https://github.com/FasterXML/jackson-databind/issues/2816