### PR TITLE
[FLINK-29631] Update Jackson-bom to 2.13.4.20221013

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.13.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
@@ -8,6 +8,6 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.module:jackson-module-jsonSchema:2.13.4
 - javax.validation:validation-api:1.1.0.Final

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
     <properties>
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
         <netty.version>4.1.82.Final</netty.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.13.4.20221013</jackson.version>
         <!-- The license check requires the artifactId to match the directory that the module resides in.
              This is not the case for several modules in flink-shaded for legacy reasons.
              This property can be used by modules to add a suffix to the artifactId to match the directory name on CI


### PR DESCRIPTION
Update of jackson-bom because of CVE-2022-42003
this was fixed within https://github.com/FasterXML/jackson-databind/issues/3590