### PR TITLE
[FLINK-29889][netty] Bundle tcnative-classes

### DIFF
--- a/flink-shaded-netty-tcnative-static/pom.xml
+++ b/flink-shaded-netty-tcnative-static/pom.xml
@@ -63,6 +63,7 @@ under the License.
                             <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <artifactSet>
                                 <includes>
+                                    <include>io.netty:netty-tcnative-classes</include>
                                     <include>io.netty:netty-tcnative-boringssl-static</include>
                                 </includes>
                             </artifactSet>

--- a/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-netty-tcnative-static/src/main/resources/META-INF/NOTICE
@@ -7,6 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - io.netty:netty-tcnative-boringssl-static:2.0.54.Final
+- io.netty:netty-tcnative-classes:2.0.54.Final
 
 This project bundles the following dependencies under the OpenSSL license.
 See bundled license files for details.


### PR DESCRIPTION
```
Nov 03 12:44:46 [INFO] --- maven-shade-plugin:3.1.1:shade (shade-flink) @ flink-shaded-netty-tcnative-static ---
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:2.0.54.Final in the shaded jar.
PROBLEM -> Nov 03 12:44:47 [INFO] Excluding io.netty:netty-tcnative-classes:jar:2.0.54.Final from the shaded jar.
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.54.Final in the shaded jar.
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.54.Final in the shaded jar.
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.54.Final in the shaded jar.
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.54.Final in the shaded jar.
Nov 03 12:44:47 [INFO] Including io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.54.Final in the shaded jar.
```