### PR TITLE
[hotfix][docs] Adds clean to Maven command in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When using these dependencies it is recommended to work directly against the sha
 
 We currently do not release jars containing the shaded sources due to the unanswered legal questions raised [here](https://github.com/apache/flink-shaded/issues/25).
 
-However, it is possible to build these jars locally by cloning the repository and calling `mvn package -Dshade-sources`.
+However, it is possible to build these jars locally by cloning the repository and calling `mvn clean package -Dshade-sources`.
 
 ## About
 


### PR DESCRIPTION
The build should be done on a fresh checkout of the flink-shaded repository. Otherwise, we might run into errors in the jackson submodule:

```
$ mvn install -Dshade-sources
[...]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (shade-flink) on project flink-shaded-jackson: Error creating shaded jar: duplicate entry: META-INF/services/org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory -> [Help 1]                                                            
[ERROR]                                                                                                                                                                                                                                                                                                                                            
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.                                                                                                                                                                                                                                                                
[ERROR] Re-run Maven using the -X switch to enable full debug logging.                                                                                                                                                                                                                                                                             
[ERROR]                                                                                                                                                                                                                                                                                                                                            
[ERROR] For more information about the errors and possible solutions, please read the following articles:                                                                                                                                                                                                                                          
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException                                                                                                                                                                                                                                                           
[ERROR]                                                                                                                                                                                                                                                                                                                                            
[ERROR] After correcting the problems, you can resume the build with the command                                                                                                                                                                                                                                                                   
[ERROR]   mvn <args> -rf :flink-shaded-jackson
```

I didn't check where this error is coming from. But building the sources based on a clean version sounds reasonable in general.