### PR TITLE
[FLINK-34234] Bumping version of flatten plugin to 1.2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,6 @@ jobs:
 
       - name: Check licensing
         run: |
-          mvn ${MVN_COMMON_OPTIONS} exec:java@check-licensing -N \
+          mvn ${MVN_COMMON_OPTIONS} exec:java@check-license -N \
             -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) ${{ env.MVN_VALIDATION_DIR }}" \
             -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties

--- a/pom.xml
+++ b/pom.xml
@@ -341,10 +341,12 @@ under the License.
                         <goals>
                             <goal>java</goal>
                         </goals>
+                        <configuration>
+                            <mainClass>org.apache.flink.tools.ci.licensecheck.LicenseChecker</mainClass>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>org.apache.flink.tools.ci.licensecheck.LicenseChecker</mainClass>
                     <includePluginDependencies>true</includePluginDependencies>
                     <includeProjectDependencies>false</includeProjectDependencies>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@ under the License.
                     <!-- Used to resolve variables in the 'version' tag -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.2.1</version>
+                    <version>1.2.7</version>
                     <executions>
                         <execution>
                             <id>flatten</id>
@@ -354,7 +354,7 @@ under the License.
                     <dependency>
                         <groupId>org.apache.flink</groupId>
                         <artifactId>flink-ci-tools</artifactId>
-                        <version>1.17-SNAPSHOT</version>
+                        <version>1.18.0</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
~~As a test [1] there was first a commit with enabling `ShadeOptionalChecker` however without adding `optional`. As a result it detects the issue i a number of places.~~


UPD: Since bumping version of flatten plugin helps I reverted changes (to not force push) and added version bump itself to 1.2.7
also keep a couple of hotfix commits as a result of review