### PR TITLE
[FLINK-35003] Update zookeeper to 3.8.4 to address CVE-2024-23944.

### DIFF
--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-38/pom.xml
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-38/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <version>${zookeeper.version}-19.0</version>
 
     <properties>
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
         <curator.version>5.4.0</curator.version>
     </properties>
 

--- a/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-38/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-zookeeper-parent/flink-shaded-zookeeper-38/src/main/resources/META-INF/NOTICE
@@ -21,5 +21,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.curator:curator-client:5.4.0
 - org.apache.curator:curator-framework:5.4.0
 - org.apache.curator:curator-recipes:5.4.0
-- org.apache.zookeeper:zookeeper-jute:3.8.3
-- org.apache.zookeeper:zookeeper:3.8.3
+- org.apache.zookeeper:zookeeper-jute:3.8.4
+- org.apache.zookeeper:zookeeper:3.8.4


### PR DESCRIPTION
JIRA: FLINK-35003. Update zookeeper to 3.8.4 to address CVE-2024-23944.

From the maven link, we can know that CVE-2024-23944 exists in zookpeer-3.8.3, and we can upgrade to zookpeer-3.8.4 to solve this issue.

https://mvnrepository.com/artifact/org.apache.zookeeper/zookeeper/3.8.3