### PR TITLE
[FLINK-35696] Shade com.jayway.jsonpath:json-path

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
@@ -24,65 +24,57 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-shaded</artifactId>
-        <version>19.0</version>
+        <artifactId>flink-shaded-jackson-parent</artifactId>
+        <version>2.15.3-19.0</version>
     </parent>
 
-    <artifactId>flink-shaded-jackson-parent</artifactId>
-    <name>flink-shaded-jackson-parent</name>
-    <packaging>pom</packaging>
-    <version>2.15.3-19.0</version>
+    <artifactId>flink-shaded-jsonpath</artifactId>
+    <name>flink-shaded-jsonpath</name>
+    <!-- override version to jsonpath version -->
+    <version>2.7.0-19.0</version>
 
-    <modules>
-        <module>flink-shaded-jackson-2</module>
-        <module>flink-shaded-jackson-module-jsonSchema-2</module>
-        <module>flink-shaded-jsonpath</module>
-    </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jsonpath.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <!-- Jackson uses multi release jars and in case 2.15.x there is version 19
+                which is not supported by 3.3.x and below -->
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>shade-flink</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
                         <configuration>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <artifactSet>
-                                <includes>
-                                    <include>com.fasterxml.jackson.*:*</include>
+                                <includes combine.children="append">
+                                    <include>com.jayway.jsonpath:json-path</include>
                                 </includes>
                             </artifactSet>
-                            <relocations>
+                            <relocations combine.children="append">
                                 <relocation>
-                                    <!-- This needs to match flink-shaded-swagger -->
-                                    <pattern>com.fasterxml.jackson</pattern>
-                                    <shadedPattern>${shading.prefix}.jackson2.com.fasterxml.jackson</shadedPattern>
+                                    <pattern>com.jayway.jsonpath</pattern>
+                                    <shadedPattern>${shading.prefix}.com.jayway.jsonpath
+                                    </shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <!-- Used to resolve variables in the 'version' tag -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/flink-shaded-jackson-parent/flink-shaded-jsonpath/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jsonpath/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-shaded-jsonpath
+Copyright 2014-2024 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.jayway.jsonpath:json-path:2.7.0

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -36,6 +36,9 @@ under the License.
     <modules>
         <module>flink-shaded-jackson-2</module>
         <module>flink-shaded-jackson-module-jsonSchema-2</module>
+        <!-- It's under jackson-parent even though it's not its subproject in order to apply the
+         same jackson shading from the parent pom. This jackson shading is what we're interested in
+         principle, because that way we can configure JsonPath mappings.-->
         <module>flink-shaded-jsonpath</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
         <netty.version>4.1.100.Final</netty.version>
         <jackson.version>2.15.3</jackson.version>
+        <jsonpath.version>2.7.0</jsonpath.version>
         <guava.version>32.1.3-jre</guava.version>
         <!-- The license check requires the artifactId to match the directory that the module resides in.
              This is not the case for several modules in flink-shaded for legacy reasons.


### PR DESCRIPTION
We need a shaded version of `jsonpath` because we'd like to configure it with shaded versions of jackson in https://github.com/apache/flink/blob/27287a105f6585e89795e2a6cbffa8254abb6e57/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java#L76

I'm intentionally putting that under `jackson` even though it's not its subproject in order to apply the same jackson shading. After all this is the reason we shade jsonpath anyhow.