### PR TITLE
[FLINK-33571] Update json-path to 2.9.0

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <artifactId>flink-shaded-jsonpath</artifactId>
     <name>flink-shaded-jsonpath</name>
     <!-- override version to jsonpath version -->
-    <version>2.7.0-20.0</version>
+    <version>2.9.0-20.0</version>
 
     <dependencies>
         <dependency>

--- a/flink-shaded-jackson-parent/flink-shaded-jsonpath/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jsonpath/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.jayway.jsonpath:json-path:2.7.0
+- com.jayway.jsonpath:json-path:2.9.0

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ under the License.
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
         <netty.version>4.1.100.Final</netty.version>
         <jackson.version>2.15.3</jackson.version>
-        <jsonpath.version>2.7.0</jsonpath.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
         <guava.version>32.1.3-jre</guava.version>
         <!-- The license check requires the artifactId to match the directory that the module resides in.
              This is not the case for several modules in flink-shaded for legacy reasons.


### PR DESCRIPTION
Update json-path library to address CVE-2023-1370 and CVE-2023-51074.