### PR TITLE
[hotfix] Bump Java setup action to version 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 8
           distribution: 'temurin'


### PR DESCRIPTION
To fix the failure https://github.com/apache/flink-shaded/actions/runs/17829169397/job/50701063021

also explained at https://github.com/actions/setup-java/issues/902