### PR TITLE
[FLINK-39557] Generate correct Multi-Release JAR files for Jackson and Swagger

### DIFF
--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -98,6 +98,13 @@ under the License.
                                     </shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers combine.children="append">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -80,6 +80,13 @@ under the License.
                                     </shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers combine.children="append">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -80,6 +80,16 @@ under the License.
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${shading.prefix}.jackson2.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
+                                <!--
+                                Manually relocate multi-release classes to the correct shaded package. This is needed
+                                due to a bug in the Maven Shade plugin, which only relocates the content but not
+                                the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+                                -->
+                                <relocation>
+                                    <pattern>META-INF/versions/(\d+)/(.+)/</pattern>
+                                    <shadedPattern>META-INF/versions/$1/${shading.prefix-directory}/jackson2/$2/</shadedPattern>
+                                    <rawString>true</rawString>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/flink-shaded-swagger/pom.xml
+++ b/flink-shaded-swagger/pom.xml
@@ -96,6 +96,13 @@ under the License.
                                     <shadedPattern>${shading.prefix}.jackson2.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers combine.children="append">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ under the License.
 
     <properties>
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
+        <shading.prefix-directory>org/apache/flink/shaded</shading.prefix-directory>
         <netty.version>4.2.12.Final</netty.version>
         <jackson.version>2.20.1</jackson.version>
         <jsonpath.version>2.10.0</jsonpath.version>
@@ -184,6 +185,7 @@ under the License.
                                 <artifact>*</artifact>
                                 <excludes>
                                     <exclude>META-INF/maven/**</exclude>
+                                    <exclude>**/module-info.class</exclude>
                                 </excludes>
                             </filter>
                         </filters>


### PR DESCRIPTION
Changes:
* JAR files that were originally multi-release are correctly marked in MANIFEST.MF (`Multi-Release: true`):
  * flink-shaded-jackson-2.20.1-21.0.jar
  * flink-shaded-jackson-module-jsonSchema-2.20.1-21.0.jar
  * flink-shaded-swagger-21.0.jar
* multi-release artifacts are relocated to locations reflecting their renamed packages
* module-info.class is excluded from all artifacts, it isn't rewritten by maven-shade-plugin, which was complaining about this in logs:
  ```
  [WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
  ```

Build log is the same as before changes, but without warnings about module-info.class. I also verified that contents of generated JAR files stayed the same or changed in the way I intended.

A directory with old and new JAR files can be generated using this snippet:
```sh
mkdir jars-old jars-new
git checkout master
mvn clean
mvn package | tee jars-old/maven-log.txt
find . -path '**/target/*.jar' | xargs -I{} cp {} jars-old/
git checkout mr-jars
mvn clean
mvn package | tee jars-new/maven-log.txt
find . -path '**/target/*.jar' | xargs -I{} cp {} jars-new/
```

Looks like flink-shaded-swagger-21.0.jar isn't properly shaded, is this intentional?
```
$ jar -t --file flink-shaded-swagger-21.0.jar | grep -v org/apache/flink/shaded
io/
io/swagger/
io/swagger/v3/
io/swagger/v3/core/
...
io/swagger/v3/oas/...
javax/activation/...
javax/validation/...
javax/xml/...
javax/xml/bind/...
javax/xml/bind/annotation/...
javax/xml/bind/attachment/...
javax/xml/bind/...
META-INF/
META-INF/DEPENDENCIES
META-INF/LICENSE
META-INF/LICENSE.md
META-INF/LICENSE.txt
META-INF/licenses/
META-INF/licenses/LICENSE.jakarta_edl-v10
META-INF/MANIFEST.MF
META-INF/NOTICE
META-INF/services/
META-INF/services/org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory
META-INF/services/org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.ObjectCodec
META-INF/services/org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Module
META-INF/versions/
META-INF/versions/9/
META-INF/versions/9/javax/
META-INF/versions/9/javax/xml/
META-INF/versions/9/javax/xml/bind/
META-INF/versions/9/javax/xml/bind/ModuleUtil.class
META-INF/versions/9/org/
META-INF/versions/9/org/yaml/
META-INF/versions/9/org/yaml/snakeyaml/
META-INF/versions/9/org/yaml/snakeyaml/internal/
META-INF/versions/9/org/yaml/snakeyaml/internal/Logger$Level.class
META-INF/versions/9/org/yaml/snakeyaml/internal/Logger.class
org/
org/apache/
org/apache/commons/
org/apache/commons/lang3/...
org/apache/flink/
org/yaml/
org/yaml/snakeyaml/...
```