### PR TITLE
[FLINK-39570] Bump Jackson to 2.18.10 (release-20.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 8
           distribution: 'temurin'

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.18.2-20.0</version>
+        <version>2.18.10-20.0</version>
     </parent>
 
     <artifactId>flink-shaded-jackson${flink.ci.license.suffix}</artifactId>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.18.2
-- com.fasterxml.jackson.core:jackson-core:2.18.2
-- com.fasterxml.jackson.core:jackson-databind:2.18.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.18.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.18.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2
+- com.fasterxml.jackson.core:jackson-annotations:2.18.10
+- com.fasterxml.jackson.core:jackson-core:2.18.10
+- com.fasterxml.jackson.core:jackson-databind:2.18.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.18.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.18.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.10
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.10
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.10
 - org.yaml:snakeyaml:2.3

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.18.2-20.0</version>
+        <version>2.18.10-20.0</version>
     </parent>
 
     <artifactId>flink-shaded-jackson-module-jsonSchema${flink.ci.license.suffix}</artifactId>

--- a/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.18.2
-- com.fasterxml.jackson.core:jackson-core:2.18.2
-- com.fasterxml.jackson.core:jackson-databind:2.18.2
-- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.18.2
+- com.fasterxml.jackson.core:jackson-annotations:2.18.10
+- com.fasterxml.jackson.core:jackson-core:2.18.10
+- com.fasterxml.jackson.core:jackson-databind:2.18.10
+- com.fasterxml.jackson.module:jackson-module-jsonSchema:2.18.10
 - javax.validation:validation-api:1.1.0.Final

--- a/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
+++ b/flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-shaded-jackson-parent</artifactId>
-        <version>2.18.2-20.0</version>
+        <version>2.18.10-20.0</version>
     </parent>
 
     <artifactId>flink-shaded-jsonpath</artifactId>

--- a/flink-shaded-jackson-parent/pom.xml
+++ b/flink-shaded-jackson-parent/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <artifactId>flink-shaded-jackson-parent</artifactId>
     <name>flink-shaded-jackson-parent</name>
     <packaging>pom</packaging>
-    <version>2.18.2-20.0</version>
+    <version>2.18.10-20.0</version>
 
     <modules>
         <module>flink-shaded-jackson-2</module>

--- a/flink-shaded-swagger/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-swagger/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.10
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.10
 - io.swagger.core.v3:swagger-annotations:2.2.19
 - io.swagger.core.v3:swagger-core:2.2.19
 - io.swagger.core.v3:swagger-models:2.2.19

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
     <properties>
         <shading.prefix>org.apache.flink.shaded</shading.prefix>
         <netty.version>4.1.100.Final</netty.version>
-        <jackson.version>2.18.2</jackson.version>
+        <jackson.version>2.18.10</jackson.version>
         <jsonpath.version>2.9.0</jsonpath.version>
         <guava.version>33.4.0-jre</guava.version>
         <!-- The license check requires the artifactId to match the directory that the module resides in.


### PR DESCRIPTION
## What

Bump the bundled Jackson on the `release-20.0` line from `2.18.2` to `2.18.10`, and update the affected `NOTICE` files and hardcoded module version coordinates to match.

## Why

`2.18.10` is the current `2.18.x` maintenance release and carries fixes for a series of `jackson-databind` / `jackson-core` CVEs and GHSA advisories reported against `2.18.2`:

`2.18.10` clears every one of these `2.18.x` fix thresholds. Because `flink-shaded` bundles (relocates) Jackson, consumers of `flink-shaded-jackson` / `flink-shaded-jackson-module-jsonSchema` / `flink-shaded-swagger` can only pick up these fixes via a rebuild of the shaded artifacts from a bumped source branch — the bundled copy is invisible to downstream `dependencyManagement`.

## Changes

- **`pom.xml`** — `jackson.version` `2.18.2` → `2.18.10`.
- **`flink-shaded-jackson-parent/pom.xml`** — hardcoded `<version>2.18.2-20.0</version>` → `2.18.10-20.0` (this module's version coordinate is `<jackson.version>-<flink-shaded-revision>` by convention, not a resolvable property).
- **`flink-shaded-jackson-parent/flink-shaded-jackson-2/pom.xml`**, **`flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/pom.xml`**, **`flink-shaded-jackson-parent/flink-shaded-jsonpath/pom.xml`** — matching `<parent><version>` bump to `2.18.10-20.0`.
- **`flink-shaded-jackson-parent/flink-shaded-jackson-2/src/main/resources/META-INF/NOTICE`** — 8 bundled `com.fasterxml.jackson.*` version lines → `2.18.10`.
- **`flink-shaded-jackson-parent/flink-shaded-jackson-module-jsonSchema-2/src/main/resources/META-INF/NOTICE`** — 4 bundled `com.fasterxml.jackson.*` version lines → `2.18.10`.
- **`flink-shaded-swagger/src/main/resources/META-INF/NOTICE`** — the 2 bundled `com.fasterxml.jackson.*` lines → `2.18.10`. This module imports `com.fasterxml.jackson:jackson-bom:${jackson.version}` in `dependencyManagement`, so the bump changes the Jackson it bundles too.
- **`.github/workflows/ci.yml`** — `actions/setup-java` `v2` → `v5` (`java-version: 8` unchanged). `v2`'s bundled Maven-cache client fails against GitHub's current cache-service backend with `Cache service responded with 400`, breaking CI on `release-20.0` before any build step runs; `master`'s workflow already moved past `v2` independently of this change.

## Verification

Built with Java 21 / Maven 3.9.4 (`mvn clean install -DskipTests -Plicense-check` equivalent reactor, against Maven Central):

- `BUILD SUCCESS` across all 16 modules.
- `flink-shaded-jackson-2-2.18.10-20.0.jar` bundles Jackson `2.18.10`, keeps the `org.apache.flink.shaded.jackson2.com.fasterxml.jackson` relocation, and shows no un-relocated `com/fasterxml/jackson` leakage.
- `license-check` profile (NoticeFileChecker) passes with the updated NOTICE files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-sonnet-5)
